### PR TITLE
Support generating module pools from Mod Selector profiles.

### DIFF
--- a/DynamicMissionGeneratorAssembly/src/MissionInputPage.cs
+++ b/DynamicMissionGeneratorAssembly/src/MissionInputPage.cs
@@ -263,7 +263,10 @@ namespace DynamicMissionGeneratorAssembly
 		{
 			moduleData.Add(new ModuleData("ALL_SOLVABLE", "[All solvable modules]"));
 			moduleData.Add(new ModuleData("ALL_NEEDY", "[All needy modules]"));
-			moduleData.Add(new ModuleData("ALL_MODS", "[All mod modules]"));
+			moduleData.Add(new ModuleData("ALL_VANILLA", "[All vanilla solvable modules]"));
+			moduleData.Add(new ModuleData("ALL_MODS", "[All mod solvable modules]"));
+			moduleData.Add(new ModuleData("ALL_VANILLA_NEEDY", "[All vanilla needy modules]"));
+			moduleData.Add(new ModuleData("ALL_MODS_NEEDY", "[All mod needy modules]"));
 			moduleData.Add(new ModuleData("frontonly", "[Front face only]"));
 			moduleData.Add(new ModuleData("nopacing", "[Disable pacing events]"));
 			moduleData.Add(new ModuleData("widgets:", "[Set widget count]"));

--- a/DynamicMissionGeneratorAssembly/src/MissionInputPage.cs
+++ b/DynamicMissionGeneratorAssembly/src/MissionInputPage.cs
@@ -53,6 +53,11 @@ namespace DynamicMissionGeneratorAssembly
 			if (File.Exists(path)) InputField.text = File.ReadAllText(path);
 		}
 
+		public void OnEnable()
+		{
+			InitModules();
+		}
+
 		public void Update()
 		{
 			if (EventSystem.current.currentSelectedGameObject == InputField.gameObject)
@@ -159,7 +164,6 @@ namespace DynamicMissionGeneratorAssembly
 
 			foreach (var item in listItems) Destroy(item);
 			listItems.Clear();
-			if (moduleData.Count == 0) InitModules();
 
 			var matches = tokenRegex.Matches(newText.Substring(0, InputField.caretPosition));
 			if (matches.Count > 0)
@@ -261,6 +265,7 @@ namespace DynamicMissionGeneratorAssembly
 
 		private static void InitModules()
 		{
+			moduleData.Clear();
 			moduleData.Add(new ModuleData("ALL_SOLVABLE", "[All solvable modules]"));
 			moduleData.Add(new ModuleData("ALL_NEEDY", "[All needy modules]"));
 			moduleData.Add(new ModuleData("ALL_VANILLA", "[All vanilla solvable modules]"));

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ To start a mission, enter a mission string into the text box, then press Enter o
   * `ALL_MODS` – any mod regular module
   * `ALL_VANILLA_NEEDY` – any vanilla needy module
   * `ALL_MODS_NEEDY` – any mod needy module
+  * `profile:[name]` – any regular module enabled by the specified profile (and not disabled by other profiles)
+  * `needyprofile:[name]` – any needy module enabled by the specified profile (and not disabled by other profiles)
 * `[h]:[m]:[s]` – sets the starting bomb time. The hours may be omitted. The default is 2 minutes per regular module.
 * `[number]X` – sets the strike limit. The default is 1 per 12 regular modules with a minimum of 3.
 * `needyactivationtime:[seconds]` – sets the time before all needy modules activate. The default is 90 seconds.


### PR DESCRIPTION
This branch adds the following special module pool tokens:

  * `profile:[name]` – any regular module enabled by the specified profile (and not disabled by other profiles)
  * `needyprofile:[name]` – any needy module enabled by the specified profile (and not disabled by other profiles)

As with module names, profile names may be enclosed in double quotes.

It also fixes a few bugs from my last pull request.